### PR TITLE
Improved Customization Update

### DIFF
--- a/tenbrushslots/Manual.html
+++ b/tenbrushslots/Manual.html
@@ -14,9 +14,10 @@
 <p>Go to <strong>Settings → Configure Krita → Keyboard Shortcuts</strong> under <strong>Ten Brush Slots</strong> to change the shortcuts. 
     Each slot has a configurable shortcut like in Ten Brushes. There are 3 additional shortcut pairs to help users switch brushes within the slots.</p>
 <p>When 2 or more kits are set up, <strong>Switch to Next/Previous Kit</strong> will cycle the kits, assigning the first brush of each slot in the kit to their respective shortcuts.</p>
-<p>Pressing the shortcut for <strong>Switch to Next/Previous Group</strong> will cycle the groups in the slot of the last activated shortcut and activate the brush in that group with its position maintained 
+<p>Pressing the shortcut for <strong>Switch to Next/Previous Group</strong> will cycle the groups in the slot with the current brush preset and activate the brush in that group with its position maintained 
     if possible. For example, if the current shortcut has a brush in the 2nd position of the 3rd group in a slot with 3 groups assigned, switching to the next group will activate a brush in the 2nd position 
     of the 1st group. If maintaining position is not possible as no brush preset is in that position of the other group, the first brush of the other group is activated instead.</p>
-<p>Pressing the shortcut for <strong>Switch to Next/Previous Position</strong> will cycle the position in the group of the last activated shortcut and activate the brush in that position.</p>
+<p>Pressing the shortcut for <strong>Switch to Next/Previous Position</strong> will cycle the position in the group with the current brush preset and activate the brush in that position. 
+    No switching will occur when the current brush does not belong in any slot and if auto-brush is active, it will still activate the brush tool.</p>
 </body>
 </html>

--- a/tenbrushslots/Manual.html
+++ b/tenbrushslots/Manual.html
@@ -13,11 +13,12 @@
     Changes in the editor are saved automatically.</p>
 <p>Go to <strong>Settings → Configure Krita → Keyboard Shortcuts</strong> under <strong>Ten Brush Slots</strong> to change the shortcuts. 
     Each slot has a configurable shortcut like in Ten Brushes. There are 3 additional shortcut pairs to help users switch brushes within the slots.</p>
-<p>When 2 or more kits are set up, <strong>Switch to Next/Previous Kit</strong> will cycle the kits, assigning the first brush of each slot in the kit to their respective shortcuts.</p>
-<p>Pressing the shortcut for <strong>Switch to Next/Previous Group</strong> will cycle the groups in the slot with the current brush preset and activate the brush in that group with its position maintained 
-    if possible. For example, if the current shortcut has a brush in the 2nd position of the 3rd group in a slot with 3 groups assigned, switching to the next group will activate a brush in the 2nd position 
-    of the 1st group. If maintaining position is not possible as no brush preset is in that position of the other group, the first brush of the other group is activated instead.</p>
-<p>Pressing the shortcut for <strong>Switch to Next/Previous Position</strong> will cycle the position in the group with the current brush preset and activate the brush in that position. 
-    No switching will occur when the current brush does not belong in any slot and if auto-brush is active, it will still activate the brush tool.</p>
+<p>When 2 or more kits are set up, <strong>Switch to Next/Previous Kit</strong> will cycle the kits, assigning the first brush preset of each slot in the following kit to their respective shortcuts. 
+    If the current or previous brush presets are in any of the slots from the following kit, they will be assigned to the slot instead.</p>
+<p>Pressing the shortcut for <strong>Switch to Next/Previous Group</strong> will cycle the groups in the slot with the current brush preset and activate the preset in the following group with its position 
+    maintained if possible. For example, if the current shortcut has a preset in the 2nd position of the 3rd group in a slot with 3 groups assigned, switching to the next group will activate a preset in the 
+    2nd position of the 1st group. If maintaining position is not possible as no brush preset is in that position of the other group, the first preset of the other group is activated instead.</p>
+<p>Pressing the shortcut for <strong>Switch to Next/Previous Position</strong> will cycle the position in the group with the current brush preset and activate the preset in the following position. 
+    No switching will occur when the current brush preset does not belong in any slot and if the auto-select brush option is active, it will still activate the brush tool.</p>
 </body>
 </html>

--- a/tenbrushslots/sloteditor.py
+++ b/tenbrushslots/sloteditor.py
@@ -129,7 +129,7 @@ class SyncConfig(QDialog):
             for i in range(self.grid.rowCount() - 1):
                 box = QCheckBox()
                 box.setTristate(True)
-                box.setToolTip(i18n("If Partially Checked, Only Presets in the Same Group will be Synced"))
+                box.setToolTip(i18n("If Partially Checked, Only Presets in the Same Group Will Be Synced"))
                 box.stateChanged.connect(self.setEdited)
                 self.grid.addWidget(box, i + 1, index + 1)
                 self.grid.setAlignment(box, Qt.AlignmentFlag.AlignCenter)
@@ -440,7 +440,7 @@ class SlotEditor(QDialog):
 
         self.activateNextBox = QGroupBox(i18n("Switch to &Next Group/Position on 2nd Press"))
         self.activateNextBox.setToolTip(
-            i18n("Overrides Switch to Previous Brush if Slot contains multiple Groups/Presets"))
+            i18n("Overrides Switch to Previous Brush if Slot Contains Multiple Groups/Presets"))
         self.activateNextBox.setCheckable(True)
         self.activateNextBox.setChecked(self.ten.activateNext)
 
@@ -457,7 +457,7 @@ class SlotEditor(QDialog):
         self.activateNextBox.setLayout(nextBoxLayout)
 
         self.autoBrushBox = QCheckBox(i18n("&Auto-Select Freehand Brush Tool"))
-        self.autoBrushBox.setToolTip(i18n("Also prevents 2nd Press Switching if Tool not selected"))
+        self.autoBrushBox.setToolTip(i18n("Also Prevents 2nd Press Switching if Tool Not Selected"))
         self.autoBrushBox.setChecked(self.ten.autoBrush)
         
         self.syncBox = QGroupBox(i18n("&Sync Settings When Switching Group/Position"))

--- a/tenbrushslots/sloteditor.py
+++ b/tenbrushslots/sloteditor.py
@@ -21,7 +21,7 @@ from PyQt5.QtCore import Qt, QSize, QItemSelectionModel
 from PyQt5.QtGui import QPixmap, QIcon, QStandardItemModel, QStandardItem
 from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel, QListView, 
                              QStyleOptionViewItem, QPushButton, QMessageBox, QCheckBox, 
-                             QGroupBox, QGridLayout, QComboBox)
+                             QGroupBox, QGridLayout, QComboBox, QListWidget, QRadioButton)
 from krita import PresetChooser
 
 ICON_WIDTH = 64
@@ -77,12 +77,163 @@ class ChoiceDialog(QDialog):
         self.setWindowTitle(i18n("Preset Chooser"))
         self.mainLayout = QVBoxLayout(self)
         self.presetChooser = PresetChooser()
-        self.presetChooser.presetClicked.connect(self.accept)
+        self.presetChooser.presetClicked.connect(self.checkPreset)
         self.mainLayout.addWidget(self.presetChooser)
+    
+    def checkPreset(self):
+        preset = self.presetChooser.currentPreset()
+        if "," in preset.name() or ";" in preset.name():
+            QMessageBox().warning(self, i18n("Preset Chooser"), 
+            i18n("Unable to read commas( , ) and semicolons( ; ).\n\nPlease rename this preset before adding."))
+        else:
+            self.accept(preset)
 
-    def accept(self):
-        self.editor.chosenPreset = self.presetChooser.currentPreset()
+    def accept(self, preset):
+        self.editor.chosenPreset = preset
         super().accept()
+
+
+class SyncConfig(QDialog):
+
+    def __init__(self, parent):
+        super().__init__(parent)
+
+        self.editor = parent
+        self.setWindowTitle(i18n("Configure Syncing"))
+        self.mainLayout = QHBoxLayout(self)
+        self.mainLayout.setSizeConstraint(QHBoxLayout.SizeConstraint.SetFixedSize)
+        
+        self.kitList = QListWidget()
+        for index in range(self.editor.kitBox.count()):
+            self.kitList.addItem(self.editor.kitBox.itemText(index))
+        self.kitList.setCurrentRow(0)
+        self.kitList.currentItemChanged.connect(self.switchKit)
+        self.kitList.setFixedWidth(128)
+        self.mainLayout.addWidget(self.kitList)
+
+        self.grid = QGridLayout()
+        self.grid.setHorizontalSpacing(16)
+        self.mainLayout.addLayout(self.grid)
+
+        self.gridButton(i18n("&Settings / Slots"), 0, 0)
+        self.gridButton(i18n("&Erase Mode"), 1, 0)
+        self.gridButton(i18n("&Brush Size"), 2, 0)
+        self.gridButton(i18n("Painting &Opacity"), 3, 0)
+        self.gridButton(i18n("Painting &Flow"), 4, 0)
+        self.gridButton(i18n("Brush &Rotation"), 5, 0)
+        self.gridButton(i18n("Blending &Mode"), 6, 0)
+
+        for index in range(10):
+            action = self.editor.ten.actions[index]
+            self.gridButton(action.shortcut().toString(), 0, index + 1)
+            for i in range(self.grid.rowCount() - 1):
+                box = QCheckBox()
+                box.setTristate(True)
+                box.setToolTip(i18n("If Partially Checked, Only Presets in the Same Group will be Synced"))
+                box.stateChanged.connect(self.setEdited)
+                self.grid.addWidget(box, i + 1, index + 1)
+                self.grid.setAlignment(box, Qt.AlignmentFlag.AlignCenter)
+
+        self.edited = []
+        self.loadSettings(self.kitList.currentItem().text())
+
+    def gridButton(self, text: str, row: int, column: int):
+        button = QPushButton(text)
+        button.setAutoDefault(False)
+        name = f"Slot {text}" if "&" not in text else text.translate(str.maketrans("", "", "&"))
+        button.setToolTip(i18n(f"Check/Uncheck All in {name}"))
+        button.clicked.connect(self.checkAll)
+        if column > 0 and len(text) == 1:
+            button.setFixedWidth(36)
+        self.grid.addWidget(button, row, column)
+
+    def checkAll(self):
+        id = self.grid.indexOf(self.sender())
+        rows = self.grid.rowCount()
+        if id < rows:
+            if id == 0:
+                count = self.grid.count()
+                state = self.allState(count)
+                for i in range(rows + 1, count):
+                    box = self.grid.itemAt(i).widget()
+                    if type(box) is not QCheckBox:
+                        continue
+                    box.setCheckState(state)
+            else:
+                state = self.allState(10, id)
+                for i in range(10):
+                    box = self.grid.itemAtPosition(id, i + 1).widget()
+                    box.setCheckState(state)
+        else:
+            id = int(id / rows)
+            state = self.allState(rows - 1, id)
+            for i in range(rows - 1):
+                box = self.grid.itemAtPosition(i + 1, id).widget()
+                box.setCheckState(state)
+
+    def allState(self, count: int, id=0):
+        high = 0
+        low = 2
+        for i in range(count):
+            box = None
+            if count > 10:
+                box = self.grid.itemAt(i).widget()
+            elif count == 10:
+                box = self.grid.itemAtPosition(id, i + 1).widget()
+            else:
+                box = self.grid.itemAtPosition(i + 1, id).widget()
+            
+            if type(box) is not QCheckBox:
+                continue
+            
+            state = box.checkState()
+            if state > high:
+                high = state
+            if state < low:
+                low = state
+            if high == 2 and low < 2:
+                break
+        if high == low:
+            if high == 2:
+                high = 0
+            else:
+                high += 1
+        return high
+
+    def loadSettings(self, kit: str):
+        settings = self.editor.ten.sync.getSettings(kit)
+        for i, setting in enumerate(settings):
+            for j, state in enumerate(setting):
+                box = self.grid.itemAtPosition(i + 1, j + 1).widget()
+                box.setCheckState(state)
+        self.edited = []
+
+    def saveSettings(self, kit: str):
+        states = []
+        for id in self.edited:
+            box = self.grid.itemAt(id).widget()
+            states.append(box.checkState())
+        if len(self.edited) == len(states):
+            self.editor.ten.sync.changeSettings(kit, self.edited, states)
+            self.editor.ten.updateSettings = True
+
+    def setEdited(self, state):
+        id = self.grid.indexOf(self.sender())
+        same = self.editor.ten.sync.isStateSame(self.kitList.currentItem().text(), id, state)
+        if same and id in self.edited:
+            self.edited.remove(id)
+        elif not same and id not in self.edited:
+            self.edited.append(id)
+    
+    def switchKit(self, current, previous):
+        if self.edited:
+            self.saveSettings(previous.text())
+        self.loadSettings(current.text())
+
+    def closeEvent(self, event):
+        if self.edited:
+            self.saveSettings(self.kitList.currentItem().text())
+        event.accept()
 
 
 class PresetItem(QStandardItem):
@@ -200,18 +351,18 @@ class SlotEditor(QDialog):
         self.setFocus()
 
     def loadKits(self):
-        self.kitList = QComboBox()
-        self.kitList.addItems(self.ten.kits.keys())
-        self.kitList.setEditable(True)
-        self.kitList.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
-        self.kitList.setMinimumWidth(240)
-        self.kitList.setCurrentIndex(self.kitList.findText(self.ten.activeKit[self.windex]))
-        self.currentText = self.kitList.currentText()
+        self.kitBox = QComboBox()
+        self.kitBox.addItems(self.ten.kits.keys())
+        self.kitBox.setEditable(True)
+        self.kitBox.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
+        self.kitBox.setMinimumWidth(240)
+        self.kitBox.setCurrentIndex(self.kitBox.findText(self.ten.activeKit[self.windex]))
+        self.currentText = self.kitBox.currentText()
         self.prevText = self.currentText
-        self.kitList.editTextChanged.connect(self.setPrevText)
-        self.currentIndex = self.kitList.currentIndex()
+        self.kitBox.editTextChanged.connect(self.setPrevText)
+        self.currentIndex = self.kitBox.currentIndex()
         self.prevIndex = self.currentIndex
-        self.kitList.currentIndexChanged.connect(self.selectKit)
+        self.kitBox.currentIndexChanged.connect(self.selectKit)
 
         newKit = QPushButton()
         newKit.setAutoDefault(False)
@@ -240,7 +391,7 @@ class SlotEditor(QDialog):
         kitsLayout = QHBoxLayout()
         kitsLayout.addStretch()
         kitsLayout.addWidget(QLabel(i18n("Select Kit:")))
-        kitsLayout.addWidget(self.kitList)
+        kitsLayout.addWidget(self.kitBox)
         kitsLayout.addWidget(newKit)
         kitsLayout.addWidget(moveUp)
         kitsLayout.addWidget(moveDown)
@@ -284,60 +435,66 @@ class SlotEditor(QDialog):
                 model.appendRow(divider)
 
     def loadOptions(self):
-        self.activatePrevBox = QGroupBox(i18n("S&witch to Previous Brush on 2nd Press"))
-        self.activatePrevBox.setCheckable(True)
+        self.activatePrevBox = QCheckBox(i18n("Switch to Previous &Brush on 2nd Press"))
         self.activatePrevBox.setChecked(self.ten.activatePrev)
-        self.activatePrevBox.setToolTip(i18n("Only Switches if Slot Does Not Have Groups"))
-        self.enforcePrevBox = QCheckBox(i18n("&Enforce Switching to Previous Brush"))
-        self.enforcePrevBox.setToolTip(i18n("Ignores Switch to Next Group on 2nd Press"))
-        self.enforcePrevBox.setChecked(self.ten.enforcePrev)
 
-        prevBoxLayout = QVBoxLayout()
-        prevBoxLayout.addWidget(self.enforcePrevBox)
-        self.activatePrevBox.setLayout(prevBoxLayout)
-        panelLayout = QVBoxLayout()
-        panelLayout.addWidget(self.activatePrevBox)
-        
+        self.activateNextBox = QGroupBox(i18n("Switch to &Next Group/Position on 2nd Press"))
+        self.activateNextBox.setToolTip(
+            i18n("Overrides Switch to Previous Brush if Slot contains multiple Groups/Presets"))
+        self.activateNextBox.setCheckable(True)
+        self.activateNextBox.setChecked(self.ten.activateNext)
+
+        self.nextGroupButton = QRadioButton(i18n("&Group"))
+        nextPositionButton = QRadioButton(i18n("&Position"))
+        if self.ten.nextGroup:
+            self.nextGroupButton.setChecked(True)
+        else:
+            nextPositionButton.setChecked(True)
+
+        nextBoxLayout = QHBoxLayout()
+        nextBoxLayout.addWidget(self.nextGroupButton)
+        nextBoxLayout.addWidget(nextPositionButton)
+        self.activateNextBox.setLayout(nextBoxLayout)
+
         self.autoBrushBox = QCheckBox(i18n("&Auto-Select Freehand Brush Tool"))
-        self.autoBrushBox.setToolTip(i18n("Also Prevents 2nd Press Actions if Tool Not Selected"))
+        self.autoBrushBox.setToolTip(i18n("Also prevents 2nd Press Switching if Tool not selected"))
         self.autoBrushBox.setChecked(self.ten.autoBrush)
-        panelLayout.addSpacing(4)
-        panelLayout.addWidget(self.autoBrushBox)
         
         self.syncBox = QGroupBox(i18n("&Sync Settings When Switching Group/Position"))
         self.syncBox.setCheckable(True)
         self.syncBox.setChecked(self.ten.sync.active)
-        self.sizeBox = QCheckBox(i18n("Brush Si&ze"))
-        self.sizeBox.setChecked(self.ten.sync.size)
-        self.opacityBox = QCheckBox(i18n("Painting Opa&city"))
-        self.opacityBox.setChecked(self.ten.sync.opacity)
-        self.flowBox = QCheckBox(i18n("Painting &Flow"))
-        self.flowBox.setChecked(self.ten.sync.flow)
-        self.eraseBox = QCheckBox(i18n("E&rase Mode"))
-        self.eraseBox.setChecked(self.ten.sync.erase)
 
-        syncBoxLayout = QGridLayout()
-        syncBoxLayout.addWidget(self.sizeBox, 0 ,0)
-        syncBoxLayout.addWidget(self.opacityBox, 0 ,1)
-        syncBoxLayout.addWidget(self.flowBox, 1 ,1)
-        syncBoxLayout.addWidget(self.eraseBox, 1 ,0)
+        configButton = QPushButton(i18n("&Configure Syncing"))
+        configButton.setAutoDefault(False)
+        configButton.clicked.connect(self.openConfig)
+        
+        syncBoxLayout = QVBoxLayout()
+        syncBoxLayout.addWidget(configButton)
         self.syncBox.setLayout(syncBoxLayout)
 
-        optionsLayout = QHBoxLayout()
-        optionsLayout.addLayout(panelLayout)
-        optionsLayout.addWidget(self.syncBox)
+        optionsLayout = QGridLayout()
+        optionsLayout.addWidget(self.activatePrevBox, 0, 0)
+        optionsLayout.addWidget(self.activateNextBox, 1, 0)
+        optionsLayout.addWidget(self.autoBrushBox, 0, 1)
+        optionsLayout.addWidget(self.syncBox, 1, 1)
+        optionsLayout.setVerticalSpacing(16)
         self.mainLayout.addLayout(optionsLayout)
+
+    def openConfig(self):
+        self.saveKit(self.currentIndex, self.currentText)
+        config = SyncConfig(self)
+        config.exec()
 
     def setPrevText(self):
         self.prevText = self.currentText
-        self.currentText = self.kitList.currentText()
+        self.currentText = self.kitBox.currentText()
     
     def selectKit(self):
         if self.currentIndex == -2:
             return
         
         self.prevIndex = self.currentIndex
-        self.currentIndex = self.kitList.currentIndex()
+        self.currentIndex = self.kitBox.currentIndex()
         if self.prevIndex != -1:
             self.saveKit(self.prevIndex, self.prevText)
         
@@ -350,7 +507,7 @@ class SlotEditor(QDialog):
 
     def getUniqueName(self, name: str):
         copy = i18n("Copy")
-        while self.kitList.findText(name) != -1:
+        while self.kitBox.findText(name) != -1:
             name += f"({copy})"
         return name
     
@@ -359,28 +516,28 @@ class SlotEditor(QDialog):
         self.currentIndex = -1
 
         name = self.getUniqueName(i18n("New"))
-        self.kitList.addItem(name)
+        self.kitBox.addItem(name)
         
-        index = self.kitList.findText(name)
-        self.kitList.setCurrentIndex(index)
+        index = self.kitBox.findText(name)
+        self.kitBox.setCurrentIndex(index)
 
     def moveKit(self):
-        length = self.kitList.count()
+        length = self.kitBox.count()
         if length > 1:
             self.saveKit(self.currentIndex, self.currentText)
-            kit = self.kitList.itemText(self.currentIndex)
+            kit = self.kitBox.itemText(self.currentIndex)
 
-            if self.kitList.sender().toolTip() == i18n("Move Down Selected Kit") and self.currentIndex < length - 1:
+            if self.kitBox.sender().toolTip() == i18n("Move Down Selected Kit") and self.currentIndex < length - 1:
                 destination = self.currentIndex + 1
-            elif self.kitList.sender().toolTip() == i18n("Move Up Selected Kit") and self.currentIndex > 0:
+            elif self.kitBox.sender().toolTip() == i18n("Move Up Selected Kit") and self.currentIndex > 0:
                 destination = self.currentIndex - 1
             else:
                 return
             
             self.currentIndex = -2
-            self.kitList.removeItem(self.kitList.currentIndex())
-            self.kitList.insertItem(destination, kit)
-            self.kitList.setCurrentIndex(destination)
+            self.kitBox.removeItem(self.kitBox.currentIndex())
+            self.kitBox.insertItem(destination, kit)
+            self.kitBox.setCurrentIndex(destination)
             self.currentIndex = destination
 
     def deleteKit(self):
@@ -389,14 +546,16 @@ class SlotEditor(QDialog):
                                               QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
         
         if confirmDelete == QMessageBox.StandardButton.Yes:
-            kit = self.kitList.itemText(self.currentIndex)
+            kit = self.kitBox.itemText(self.currentIndex)
             self.ten.removeKit(kit)
+            if self.ten.sync.isKitStored(kit):
+                self.ten.sync.removeKit(kit)
             
-            if self.kitList.count() > 1:
+            if self.kitBox.count() > 1:
                 self.currentIndex = -1
-                self.kitList.removeItem(self.kitList.currentIndex())
+                self.kitBox.removeItem(self.kitBox.currentIndex())
             else:
-                self.kitList.setItemText(0, "")
+                self.kitBox.setItemText(0, "")
                 self.slot.clear()
 
     def insertPreset(self):
@@ -409,8 +568,7 @@ class SlotEditor(QDialog):
                 prevIndex = self.slot.presets[preset.name()]
                 shortcut = self.slot.shortcuts[prevIndex]
                 movePreset = QMessageBox().question(self, i18n("Preset Chooser"), 
-                                                    i18n(f"Preset already in slot {shortcut}.\n\nMove it instead?"), 
-                                                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+                                                    i18n(f"Preset already in slot {shortcut}.\n\nMove it instead?"))
                 
                 if movePreset == QMessageBox.StandardButton.No:
                     return
@@ -534,26 +692,44 @@ class SlotEditor(QDialog):
             return slots
     
     def saveKit(self, index: int, text: str):
-        kit = self.kitList.itemText(index)
+        kit = self.kitBox.itemText(index)
+        text = text.replace(",", " ")
+        stored = self.ten.sync.isKitStored(kit)
 
         if kit != text:
             name = self.getUniqueName(text)
-            self.kitList.setItemText(index, name)
+            self.kitBox.setItemText(index, name)
             if kit in self.ten.kits:
                 self.ten.updateName(kit, name)
+            if stored:
+                self.ten.sync.renameKit(kit, name)
             kit = name
-
+        
         slots = self.editedSlots(kit)
         if slots:
-            self.ten.updateKit(kit ,slots)
+            self.ten.updateKit(kit, slots)
+            if not stored:
+                self.ten.sync.newKit(kit)
 
-    def saveOptions(self):
+    def closeEvent(self, event):
+        self.saveKit(self.currentIndex, self.currentText)
+        
+        kitOrder = []
+        for index in range(self.kitBox.count()):
+            kitOrder.append(self.kitBox.itemText(index))
+        if kitOrder != list(self.ten.kits.keys()):
+            self.ten.reorderKits(kitOrder)
+        
         if self.ten.activatePrev != self.activatePrevBox.isChecked():
             self.ten.activatePrev = self.activatePrevBox.isChecked()
             self.ten.updateSettings = True
-        
-        if self.ten.enforcePrev != self.enforcePrevBox.isChecked():
-            self.ten.enforcePrev = self.enforcePrevBox.isChecked()
+
+        if self.ten.activateNext != self.activateNextBox.isChecked():
+            self.ten.activateNext = self.activateNextBox.isChecked()
+            self.ten.updateSettings = True
+
+        if self.ten.nextGroup != self.nextGroupButton.isChecked():
+            self.ten.nextGroup = self.nextGroupButton.isChecked()
             self.ten.updateSettings = True
         
         if self.ten.autoBrush != self.autoBrushBox.isChecked():
@@ -563,34 +739,6 @@ class SlotEditor(QDialog):
         if self.ten.sync.active != self.syncBox.isChecked():
             self.ten.sync.active = self.syncBox.isChecked()
             self.ten.updateSettings = True
-        
-        if self.ten.sync.size != self.sizeBox.isChecked():
-            self.ten.sync.size = self.sizeBox.isChecked()
-            self.ten.updateSettings = True
-        
-        if self.ten.sync.opacity != self.opacityBox.isChecked():
-            self.ten.sync.opacity = self.opacityBox.isChecked()
-            self.ten.updateSettings = True
-        
-        if self.ten.sync.flow != self.flowBox.isChecked():
-            self.ten.sync.flow = self.flowBox.isChecked()
-            self.ten.updateSettings = True
-        
-        if self.ten.sync.erase != self.eraseBox.isChecked():
-            self.ten.sync.erase = self.eraseBox.isChecked()
-            self.ten.updateSettings = True
-
-    def closeEvent(self, event):
-        self.saveKit(self.currentIndex, self.currentText)
-        self.currentText = self.kitList.itemText(self.currentIndex)
-        
-        kitOrder = []
-        for index in range(self.kitList.count()):
-            kitOrder.append(self.kitList.itemText(index))
-        if kitOrder != list(self.ten.kits.keys()):
-            self.ten.reorderKits(kitOrder)
-        
-        self.saveOptions()
 
         if self.currentText != self.ten.activeKit[self.windex] or self.currentText in self.ten.kitsEdited:
             self.ten.setActiveKit(self.currentText, self.windex)

--- a/tenbrushslots/tenbrushslots.py
+++ b/tenbrushslots/tenbrushslots.py
@@ -58,12 +58,112 @@ class ActionCycle:
 
 class SlotSync:
 
-    def __init__(self, active=False, size=True, opacity=True, flow=True, erase=True):
-        self.active = active
-        self.size = size
-        self.opacity = opacity
-        self.flow = flow
-        self.erase = erase
+    def __init__(self):
+        self.active = True
+        self.erase = {}
+        self.size = {}
+        self.opacity = {}
+        self.flow = {}
+        self.rotation = {}
+        self.blending = {}
+
+    def isStateSame(self, kit: str, id: int, state: int):
+        option = id % 7
+        slot = int(((id - option) / 7) - 1)
+        if 0 <= slot <= 9:
+            match option:
+                case 1:
+                    return self.erase[kit][slot] == state
+                case 2:
+                    return self.size[kit][slot] == state
+                case 3:
+                    return self.opacity[kit][slot] == state
+                case 4:
+                    return self.flow[kit][slot] == state
+                case 5:
+                    return self.rotation[kit][slot] == state
+                case 6:
+                    return self.blending[kit][slot] == state
+
+    def isKitStored(self, kit: str):
+        return all([kit in self.erase, kit in self.size, kit in self.opacity, 
+                    kit in self.flow, kit in self.rotation, kit in self.blending])
+    
+    def newKit(self, kit: str):
+        setting = []
+        for _ in range(10):
+            setting.append(2)
+        self.erase[kit] = setting.copy()
+        self.size[kit] = setting.copy()
+        self.opacity[kit] = setting.copy()
+        self.flow[kit] = setting.copy()
+        self.rotation[kit] = setting.copy()
+        self.blending[kit] = setting.copy()
+
+    def removeKit(self, kit: str):
+        return [self.erase.pop(kit), self.size.pop(kit), self.opacity.pop(kit), 
+                self.flow.pop(kit), self.rotation.pop(kit), self.blending.pop(kit)]
+
+    def renameKit(self, prevName: str, newName: str):
+        settings = self.removeKit(prevName)
+        self.erase[newName] = settings[0]
+        self.size[newName] = settings[1]
+        self.opacity[newName] = settings[2]
+        self.flow[newName] = settings[3]
+        self.rotation[newName] = settings[4]
+        self.blending[newName] = settings[5]
+
+    def changeSettings(self, kit: str, ids, states):
+        for index, id in enumerate(ids):
+            option = id % 7
+            slot = int(((id - option) / 7) - 1)
+            if 0 <= slot <= 9:
+                match option:
+                    case 1:
+                        self.erase[kit][slot] = states[index]
+                    case 2:
+                        self.size[kit][slot] = states[index]
+                    case 3:
+                        self.opacity[kit][slot] = states[index]
+                    case 4:
+                        self.flow[kit][slot] = states[index]
+                    case 5:
+                        self.rotation[kit][slot] = states[index]
+                    case 6:
+                        self.blending[kit][slot] = states[index]
+
+    def getSettings(self, kit: str):
+        return [self.erase[kit], self.size[kit], self.opacity[kit], 
+                self.flow[kit], self.rotation[kit], self.blending[kit]]
+
+    def getString(self, kit: str):
+        ids = []
+        states = []
+        for index, state in enumerate(self.erase[kit]):
+            if state != 2:
+                ids.append(str((index + 1) * 7 + 1))
+                states.append(str(state))
+        for index, state in enumerate(self.size[kit]):
+            if state != 2:
+                ids.append(str((index + 1) * 7 + 2))
+                states.append(str(state))
+        for index, state in enumerate(self.opacity[kit]):
+            if state != 2:
+                ids.append(str((index + 1) * 7 + 3))
+                states.append(str(state))
+        for index, state in enumerate(self.flow[kit]):
+            if state != 2:
+                ids.append(str((index + 1) * 7 + 4))
+                states.append(str(state))
+        for index, state in enumerate(self.rotation[kit]):
+            if state != 2:
+                ids.append(str((index + 1) * 7 + 5))
+                states.append(str(state))
+        for index, state in enumerate(self.blending[kit]):
+            if state != 2:
+                ids.append(str((index + 1) * 7 + 6))
+                states.append(str(state))
+        return ";".join([",".join(ids), ",".join(states)]) 
 
 
 class TenBrushSlots(Extension):
@@ -78,16 +178,17 @@ class TenBrushSlots(Extension):
         self.currentSlot = []
         # Store parameters to shortcuts
         self.actions = []
-        # Parameters to activate previous slot/preset
+        # Parameters to activate previous preset and next group/position
         self.activatePrev = True
-        self.enforcePrev = False
+        self.activateNext = True
+        self.nextGroup = True
         self.prevPreset = []
         self.prevSlot = []
         # Parameters for auto brush tool
         self.autoBrush = True
         self.brushTool = None
         # Sync preset settings when cycling in slot
-        self.sync = SlotSync(True)
+        self.sync = SlotSync()
         # Checks if editor updated slots/settings
         self.kitsEdited = []
         self.updateSettings = False
@@ -99,13 +200,27 @@ class TenBrushSlots(Extension):
     def setup(self):
         self.readSettings()
         notify = Application.notifier()
-        notify.setActive(True)
         notify.windowCreated.connect(self.newWindow)
+        notify.imageClosed.connect(self.resetCurrent)
+        notify.setActive(True)
 
     def newWindow(self):
         windows = Application.windows()
         windows[-1].windowClosed.connect(self.resetPointers)
         self.loadTool()
+        self.resetCurrent()
+
+    def resetCurrent(self):
+        if Application.activeWindow().views():
+            return
+        
+        preset = Application.readSetting("", "LastPreset", "")
+        allPresets = Application.resources('preset')
+        if preset in allPresets:
+            window = list(Application.windows()).index(Application.activeWindow())
+            slot = self.findPreset(preset, window)
+            if slot is not None:
+                self.currentSlot[window] = slot
 
     def resetPointers(self):
         if Application.windows():
@@ -166,11 +281,52 @@ class TenBrushSlots(Extension):
     
     def setActiveKit(self, kit: str, window: int):
         self.activeKit[window] = kit
+
+        preset = Application.readSetting("", "LastPreset", "")
+        view = Application.activeWindow().activeView()
+        if view.visible():
+            preset = view.currentBrushPreset().name()
+
+        currentSlot = None
+        allPresets = Application.resources('preset')
+        if preset in allPresets:
+            currentSlot = self.findPreset(preset, window)
+            if currentSlot is not None:
+                self.currentSlot[window] = currentSlot
+
+        prevSlot = None
+        if self.prevPreset[window]:
+            preset = self.prevPreset[window].name()
+            if preset in allPresets:
+                prevSlot = self.findPreset(preset, window, currentSlot)
+                if prevSlot is not None:
+                    self.prevSlot[window] = prevSlot
+
         start = window * ACTIONS
         for index, action in enumerate(self.actions[start:start+len(SLOTS)]):
-            action.preset = None
+            if index == currentSlot or index == prevSlot:
+                continue
+            
             if self.kits[kit][index]:
                 action.preset = ActionPreset(0, self.kits[kit][index][0][0])
+            else:
+                action.preset = None
+
+    def findPreset(self, presetName: str, window: int, currentSlot=None):
+        presetSlot = None
+        presetGroup = 0
+        for index, slot in enumerate(self.kits[self.activeKit[window]]):
+            if presetSlot is not None:
+                    break
+
+            for idx, group in enumerate(slot):
+                if presetName in group:
+                    presetSlot = index
+                    presetGroup = idx
+                    break
+        if presetSlot is not None and presetSlot != currentSlot:
+            self.actions[presetSlot + window*ACTIONS].preset = ActionPreset(presetGroup, presetName)
+        return presetSlot
     
     def readSettings(self):
         allPresets = Application.resources('preset')
@@ -187,16 +343,21 @@ class TenBrushSlots(Extension):
                 slot = [group for group in slot if group]
                 self.kits[kit].append(slot)
 
+            self.sync.newKit(kit)
+            sync = Application.readSetting(MENU_ENTRY, f"{index}sync", "").split(";")
+            if len(sync) ==  2:
+                ids = [int(id) for id in sync[0].split(",") if id.isdecimal()]
+                states = [int(state) for state in sync[1].split(",") if state == "0" or state == "1"]
+                if len(ids) == len(states):
+                    self.sync.changeSettings(kit, ids, states)
+
         options = Application.readSetting(MENU_ENTRY, "options", "").split(",")
-        if len(options) == 8:
+        if len(options) >= 5:
             self.activatePrev = options[0] == "True"
-            self.enforcePrev = options[1] == "True"
-            self.autoBrush = options[2] == "True"
-            self.sync.active = options[3] == "True"
-            self.sync.size = options[4] == "True"
-            self.sync.opacity = options[5] == "True"
-            self.sync.flow = options[6] == "True"
-            self.sync.erase = options[7] == "True"
+            self.activateNext = options[1] == "True"
+            self.nextGroup = options[2] == "True"
+            self.autoBrush = options[3] == "True"
+            self.sync.active = options[4] == "True"
 
     def writeSettings(self):
         kits = list(self.kits.keys())
@@ -207,18 +368,17 @@ class TenBrushSlots(Extension):
                 slot = [",".join(group) for group in self.kits[kit][idx]]
                 Application.writeSetting(MENU_ENTRY, f"{index}slot{number}", ";".join(slot))
 
+            Application.writeSetting(MENU_ENTRY, f"{index}sync", self.sync.getString(kit))
+
         options = []
         options.append(str(self.activatePrev))
-        options.append(str(self.enforcePrev))
+        options.append(str(self.activateNext))
+        options.append(str(self.nextGroup))
         options.append(str(self.autoBrush))
         options.append(str(self.sync.active))
-        options.append(str(self.sync.size))
-        options.append(str(self.sync.opacity))
-        options.append(str(self.sync.flow))
-        options.append(str(self.sync.erase))
         Application.writeSetting(MENU_ENTRY, "options", ",".join(options))
     
-    def loadActions(self, window) -> None:
+    def loadActions(self, window):
         kit = list(self.kits.keys())[0]
         for index, number in enumerate(SLOTS):
             action = window.createAction(f"activate_slot_{number}", i18n(f"Activate Brush Slot {number}"), "")
@@ -268,13 +428,13 @@ class TenBrushSlots(Extension):
             return
         
         window = int(self.actions.index(self.sender()) / ACTIONS)
-        preset = self.sender().preset
+        preset: ActionPreset = self.sender().preset
         if preset is None:
             self.showMessage(view, window, 'empty')
             return
             
         allPresets = Application.resources('preset')
-        if  preset.name not in allPresets:
+        if preset.name not in allPresets:
             self.showMessage(view, window, 'missing')
             return
 
@@ -282,18 +442,44 @@ class TenBrushSlots(Extension):
         slot = self.actions.index(self.sender()) % ACTIONS
         currentPreset = view.currentBrushPreset()
         if preset.name == currentPreset.name() and (not self.autoBrush or self.brushTool.isChecked()):
-            if len(self.kits[self.activeKit[window]][slot]) > 1 and not(self.activatePrev and self.enforcePrev):
+            kit = self.activeKit[window]
+            if self.activateNext and self.nextGroup and len(self.kits[kit][slot]) > 1:
                 self.currentSlot[window] = slot
                 if not self.cycleGroup(view, allPresets, preset, ActionCycle.Value, window):
                     self.showMessage(view, window, 'missing')
                     return
+            elif self.activateNext and (not self.nextGroup and 
+                                        len(self.kits[kit][slot][preset.group]) > 1):
+                self.currentSlot[window] = slot
+                if not self.cyclePosition(view, allPresets, preset, ActionCycle.Value, window):
+                    self.showMessage(view, window, 'missing')
+                    return
             elif self.activatePrev and self.prevPreset[window] is not None:
+                synced = False
+                prevName = self.prevPreset[window].name()
                 if self.currentSlot[window] != self.prevSlot[window]:
-                    self.setPrevSlot(slot, window)
-                view.activateResource(self.prevPreset[window])
+                    if slot == self.currentSlot[window]:
+                        for group in self.kits[kit][self.prevSlot[window]]:
+                            if prevName in group:
+                                self.currentSlot[window] = self.prevSlot[window]
+                                self.prevSlot[window] = slot
+                                break
+                    else:
+                        for group in self.kits[kit][self.currentSlot[window]]:
+                            if prevName in group:
+                                self.prevSlot[window] = slot
+                                break
+                else:
+                    for index, group in enumerate(self.kits[kit][slot]):
+                        if prevName in group:
+                            self.actions[slot + window*ACTIONS].preset = ActionPreset(index, prevName)
+                            synced = self.activateAndSync(view, allPresets, prevName, window, index == preset.group)
+                            break
+                if not synced:
+                    view.activateResource(self.prevPreset[window])
                 self.prevPreset[window] = currentPreset
         else:
-            if preset.name != currentPreset.name() or not self.autoBrush:
+            if preset.name != currentPreset.name():
                 self.prevPreset[window] = currentPreset
                 self.prevSlot[window] = self.currentSlot[window]
             self.currentSlot[window] = slot
@@ -302,19 +488,6 @@ class TenBrushSlots(Extension):
         if self.autoBrush:
             Application.action('KritaShape/KisToolBrush').trigger()
         self.showMessage(view, window, 'selected')
-
-    def setPrevSlot(self, slot: int, window:int):
-        if slot == self.currentSlot[window]:
-            for group in self.kits[self.activeKit[window]][self.prevSlot[window]]:
-                if self.prevPreset[window].name() in group:
-                    self.currentSlot[window] = self.prevSlot[window]
-                    self.prevSlot[window] = slot
-                    return self.prevSlot[window]
-        else:
-            for group in self.kits[self.activeKit[window]][self.currentSlot[window]]:
-                if self.prevPreset[window].name() in group:
-                    self.prevSlot[window] = slot
-                    return self.prevSlot[window]
     
     def showMessage(self, view, window: int, message: str):
         kit = self.activeKit[window]
@@ -346,22 +519,34 @@ class TenBrushSlots(Extension):
                 self.cycleKit(cycle.vector, window)
                 self.showMessage(view, window, 'kit')
             return
-        
-        preset = self.actions[self.currentSlot[window] + window*ACTIONS].preset
+
+        currentSlot = self.currentSlot[window]
+        preset: ActionPreset = self.actions[currentSlot + window*ACTIONS].preset
+        changed = False
         if preset is None:
-            self.showMessage(view, window, 'empty')
-            return
-        
-        allPresets = Application.resources('preset')
-        slot = self.kits[self.activeKit[window]][self.currentSlot[window]]
-        if cycle.order == 'group' and len(slot) > 1:
-            if not self.cycleGroup(view, allPresets, preset, cycle.vector, window):
-                self.showMessage(view, window, 'missing')
-                return
-        elif cycle.order == 'position' and len(slot[preset.group]) > 1:
-            if not self.cyclePosition(view, allPresets, preset, cycle.vector, window):
-                self.showMessage(view, window, 'missing')
-                return
+            currentSlot = self.findPreset(currentPreset.name(), window)
+            changed = True
+        else:
+            currentPreset = view.currentBrushPreset()
+            if preset.name != currentPreset.name():
+                currentSlot = self.findPreset(currentPreset.name(), window)
+                changed = True
+
+        if currentSlot is not None:
+            if changed:
+                preset = self.actions[currentSlot + window*ACTIONS].preset
+                self.currentSlot[window] = currentSlot
+            
+            allPresets = Application.resources('preset')
+            slot = self.kits[self.activeKit[window]][currentSlot]
+            if cycle.order == 'group' and len(slot) > 1:
+                if not self.cycleGroup(view, allPresets, preset, cycle.vector, window):
+                    self.showMessage(view, window, 'missing')
+                    return
+            elif cycle.order == 'position' and len(slot[preset.group]) > 1:
+                if not self.cyclePosition(view, allPresets, preset, cycle.vector, window):
+                    self.showMessage(view, window, 'missing')
+                    return
 
         if self.autoBrush:
             Application.action('KritaShape/KisToolBrush').trigger()
@@ -383,7 +568,8 @@ class TenBrushSlots(Extension):
         self.setActiveKit(kits[destination], window)
     
     def cycleGroup(self, view, allPresets: dict, preset: ActionPreset, vector: int, window: int):
-        slot = self.kits[self.activeKit[window]][self.currentSlot[window]]
+        currentSlot = self.currentSlot[window]
+        slot = self.kits[self.activeKit[window]][currentSlot]
         if not slot or preset.group >= len(slot):
             return
         
@@ -398,13 +584,14 @@ class TenBrushSlots(Extension):
 
         presetName = slot[destination][position]
         if presetName in allPresets:
-            self.actions[self.currentSlot[window] + window*ACTIONS].preset = ActionPreset(destination, presetName)
+            self.actions[currentSlot + window*ACTIONS].preset = ActionPreset(destination, presetName)
             self.prevPreset[window] = view.currentBrushPreset()
-            self.prevSlot[window] = self.currentSlot[window]
+            self.prevSlot[window] = currentSlot
             return self.activateAndSync(view, allPresets, presetName, window)
 
     def cyclePosition(self, view, allPresets: dict, preset: ActionPreset, vector: int, window: int):
-        slot = self.kits[self.activeKit[window]][self.currentSlot[window]]
+        currentSlot = self.currentSlot[window]
+        slot = self.kits[self.activeKit[window]][currentSlot]
         if not slot or preset.group >= len(slot):
             return
         
@@ -417,28 +604,38 @@ class TenBrushSlots(Extension):
         destination = self.getDestination(position, len(group), vector)
         presetName = group[destination]
         if presetName in allPresets:
-            self.actions[self.currentSlot[window] + window*ACTIONS].preset = ActionPreset(preset.group, presetName)
+            self.actions[currentSlot + window*ACTIONS].preset = ActionPreset(preset.group, presetName)
             self.prevPreset[window] = view.currentBrushPreset()
-            self.prevSlot[window] = self.currentSlot[window]
-            return self.activateAndSync(view, allPresets, presetName, window)
+            self.prevSlot[window] = currentSlot
+            return self.activateAndSync(view, allPresets, presetName, window, True)
         
-    def activateAndSync(self, view, allPresets: dict, presetName: str, window: int):
+    def activateAndSync(self, view, allPresets: dict, presetName: str, window: int, sameGroup=False):
+        erase = Application.action('erase_action')
+        state = erase.isChecked()
         size = view.brushSize()
         opacity = view.paintingOpacity()
         flow = view.paintingFlow()
-        erase = Application.action('erase_action')
-        state = erase.isChecked()
+        rotation = view.brushRotation()
+        blending = view.currentBlendingMode()
 
         view.activateResource(allPresets[presetName])
         if self.sync.active:
-            if self.sync.size:
-                view.setBrushSize(size)
-            if self.sync.opacity:
-                view.setPaintingOpacity(opacity)
-            if self.sync.flow:
-                view.setPaintingFlow(flow)
-            if self.sync.erase:
+            kit = self.activeKit[window]
+            slot = self.currentSlot[window]
+
+            if self.sync.erase[kit][slot] == 2 or (self.sync.erase[kit][slot] == 1 and sameGroup):
                 if state != erase.isChecked():
                     erase.trigger()
-        return presetName
+            if self.sync.size[kit][slot] == 2 or (self.sync.size[kit][slot] == 1 and sameGroup):
+                view.setBrushSize(size)
+            if self.sync.opacity[kit][slot] == 2 or (self.sync.opacity[kit][slot] == 1 and sameGroup):
+                view.setPaintingOpacity(opacity)
+            if self.sync.flow[kit][slot] == 2 or (self.sync.flow[kit][slot] == 1 and sameGroup):
+                view.setPaintingFlow(flow)
+            if self.sync.rotation[kit][slot] == 2 or (self.sync.rotation[kit][slot] == 1 and sameGroup):
+                view.setBrushRotation(rotation)
+            if self.sync.blending[kit][slot] == 2 or (self.sync.blending[kit][slot] == 1 and sameGroup):
+                view.setCurrentBlendingMode(blending)
+
+        return True
 

--- a/tenbrushslots/tenbrushslots.py
+++ b/tenbrushslots/tenbrushslots.py
@@ -345,14 +345,14 @@ class TenBrushSlots(Extension):
 
             self.sync.newKit(kit)
             sync = Application.readSetting(MENU_ENTRY, f"{index}sync", "").split(";")
-            if len(sync) ==  2:
+            if len(sync) == 2:
                 ids = [int(id) for id in sync[0].split(",") if id.isdecimal()]
                 states = [int(state) for state in sync[1].split(",") if state == "0" or state == "1"]
                 if len(ids) == len(states):
                     self.sync.changeSettings(kit, ids, states)
 
         options = Application.readSetting(MENU_ENTRY, "options", "").split(",")
-        if len(options) >= 5:
+        if len(options) == 5:
             self.activatePrev = options[0] == "True"
             self.activateNext = options[1] == "True"
             self.nextGroup = options[2] == "True"


### PR DESCRIPTION
## Added
### Expanded Sync Options 
- Added ability to enable different settings for individual slots of each kit
- May also enable syncing only for presets of the same group in slot

### Name Validations
- Preset Chooser now prevents preset with names containing "," or ";" from being added
- Editor will auto rename kit with names containing ","(replaced with empty space)

## Changed
### 2nd Press Switching
- Switching group to be its own option instead of being tied with switch to previous brush
- Enforce previous brush option is therefore removed
- Switching group also has additional option to switch position instead

### Switching Group/Position
- Now uses current brush preset to determine current slot instead of last activated shortcut

## Fixed
### Switch to Previous Brush
- Previous brush will now sync if in same slot/group as the current brush
- Switching group/position shortcut will now cycle properly after Switch to Previous Brush